### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-Flask
+Flask==2.0.3
 python-dateutil
 ccxt
-web3
+web3==5.28


### PR DESCRIPTION
set static version on Flask and Web3,
as newer versions broke actual code.